### PR TITLE
Change id of PartialDiscordFileAttachment to i16

### DIFF
--- a/src/entities/attachment.rs
+++ b/src/entities/attachment.rs
@@ -24,7 +24,7 @@ pub struct Attachment {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 
 pub struct PartialDiscordFileAttachment {
-    pub id: Option<Snowflake>,
+    pub id: Option<i16>,
     pub filename: String,
     pub description: Option<String>,
     pub content_type: Option<String>,
@@ -107,7 +107,7 @@ impl PartialDiscordFileAttachment {
         (content_type, updated_struct)
     }
 
-    pub fn set_id(&mut self, id: Snowflake) {
+    pub fn set_id(&mut self, id: i16) {
         self.id = Some(id);
     }
 }


### PR DESCRIPTION
The `PartialDiscordFileAttachment` is being used, when attachment is created, by our client, and made ready to be sent. The Discord API docs require, that each attachment file in a message has an `id` from 0 to N. I don't think the `Snowflake` fulfills this requirement for this specific type.

We can, however, keep the Snowflake type for the full `DiscordFileAttachment` type, if wanted/needed.